### PR TITLE
#167 - reservation form's preferred language field defaults 

### DIFF
--- a/src/Public/Models/ViewModels/ReserveSeatViewModel.cs
+++ b/src/Public/Models/ViewModels/ReserveSeatViewModel.cs
@@ -7,6 +7,12 @@ namespace Public.Models.ViewModels;
 
 public class ReserveSeatViewModel
 {
+    public ReserveSeatViewModel()
+    {
+        var culture = Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName;
+        PreferredLanguageAbbreviated = culture;
+    }
+
     /* Display only */
 
     [BindNever]
@@ -36,10 +42,17 @@ public class ReserveSeatViewModel
     [DataType(DataType.PhoneNumber)]
     public string? PhoneNumber { get; set; }
 
-    public string PreferredLanguage { get; set; } = null!;
+    public string PreferredLanguageAbbreviated { get; set; }
 
     public ReserveSeatCommand ToReserveSeatCommand(string ipAddress, LockSeatCommandResponse seatLock)
     {
+        var preferredLangauge = PreferredLanguageAbbreviated switch
+        {
+            "en" => "English",
+            "ko" => "한국어",
+            _ => throw new NotImplementedException($"Language abbreviation ${PreferredLanguageAbbreviated} is not valid."),
+        };
+
         return new ReserveSeatCommand
         {
             IpAddress = ipAddress,
@@ -47,7 +60,7 @@ public class ReserveSeatViewModel
             Email = Email,
             Name = Name,
             PhoneNumber = PhoneNumber,
-            PreferredLanguage = PreferredLanguage,
+            PreferredLanguage = preferredLangauge,
             SeatKey = seatLock.SeatKey,
             SeatNumber = seatLock.SeatNumber,
         };

--- a/src/Public/Views/Reservation/ReserveSeat.cshtml
+++ b/src/Public/Views/Reservation/ReserveSeat.cshtml
@@ -66,10 +66,10 @@
                 </div>
             </div>
             <div class="mb-3">
-                <label asp-for="PreferredLanguage" class="form-label">@Localizer["Preferred language"]</label>
-                <select asp-for="PreferredLanguage" required>
-                    <option value="English">English</option>
-                    <option value="Korean">한국어</option>
+                <label asp-for="PreferredLanguageAbbreviated" class="form-label">@Localizer["Preferred language"]</label>
+                <select asp-for="PreferredLanguageAbbreviated" class="form-select" required>
+                    <option value="en">English</option>
+                    <option value="ko">한국어</option>
                 </select>
             </div>
         </section>


### PR DESCRIPTION
Form now defaults to current UI language for preferred language field.

Closes #167